### PR TITLE
Add Clients's Websockets List and Interactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jolocom/web-service-base",
-  "version": "3.0.0-rc3",
+  "version": "3.0.0-rc4",
   "description": "Generic Jolocom Web Service for HTTP and WebSockets support for the Jolocom SDK",
   "main": "dist/index.js",
   "repository": "https://github.com/jolocom/web-service-base",


### PR DESCRIPTION
- Save the Clients's Websockets into an array
- Pass the related Client WebSocket to the Call Back function and the RPC functions
- Send the response, or the error, of the called Call Back function to the client over WebSocket
- Update version at `package.json`